### PR TITLE
Adjust transcript font size and row height logic

### DIFF
--- a/src/components/tracks/transcript/pack.tsx
+++ b/src/components/tracks/transcript/pack.tsx
@@ -21,10 +21,10 @@ export default function PackTranscript({
 }: PackTranscriptProps) {
   const { totalWidth, sideWidth } = dimensions;
   const { x, reverseX } = useXTransform(totalWidth);
-  const fontSize = 12;
+  const fontSize = 10;
 
-  const grouped = useMemo(() => groupFeatures(sortedTranscripts(data || []), x, fontSize), [data, x, fontSize]);
-
+  const sorted = useMemo(() => sortedTranscripts(data || []), [data]);
+  const grouped = useMemo(() => groupFeatures(sorted, x, fontSize), [sorted, x, fontSize]);
   const rowHeight = useRowHeight(grouped.length, id);
 
   const rendered: TranscriptRow[] = useMemo(
@@ -49,7 +49,7 @@ export default function PackTranscript({
     <g width={totalWidth} height={height} transform={`translate(-${sideWidth},0)`}>
       <rect width={totalWidth} height={height} fill={background} />
       <defs>
-        <ClipPath id={id} width={totalWidth} height={rendered.length * rowHeight} />
+        <ClipPath id={id} width={totalWidth} height={grouped.length * rowHeight} />
       </defs>
       {rendered.map((group, k) => (
         <g

--- a/src/components/tracks/transcript/squish.tsx
+++ b/src/components/tracks/transcript/squish.tsx
@@ -27,13 +27,10 @@ export default function SquishTranscript({
 }: SquishTranscriptProps) {
   const { totalWidth, sideWidth } = dimensions;
   const { x, reverseX } = useXTransform(totalWidth);
-  const fontSize = 12;
+  const fontSize = 10;
 
-  const grouped = useMemo(
-    () => groupFeatures(data?.map((gene) => mergeTranscripts(gene, geneName)) || [], x, fontSize),
-    [data, x, geneName]
-  );
-
+  const merged = useMemo(() => data?.map((gene) => mergeTranscripts(gene, geneName)), [data, geneName]);
+  const grouped = useMemo(() => groupFeatures(merged, x, fontSize), [merged, x, fontSize]);
   const rowHeight = useRowHeight(grouped.length, id);
 
   const rendered: TranscriptRow[] = useMemo(
@@ -42,7 +39,7 @@ export default function SquishTranscript({
         y: i * rowHeight,
         transcripts: group.map((transcript) => renderTranscript(transcript, x, rowHeight, totalWidth)),
       })),
-    [grouped, rowHeight, totalWidth, x, geneName]
+    [grouped, rowHeight, totalWidth, x]
   );
 
   const background = useTheme((state) => state.background);
@@ -58,7 +55,7 @@ export default function SquishTranscript({
     <g width={totalWidth} height={height} transform={`translate(-${sideWidth},0)`}>
       <rect width={totalWidth} height={height} fill={background} />
       <defs>
-        <ClipPath id={id} width={totalWidth} height={rendered.length * rowHeight} />
+        <ClipPath id={id} width={totalWidth} height={grouped.length * rowHeight} />
       </defs>
       {rendered.map((group, k) => (
         <g

--- a/src/hooks/useRowHeight.ts
+++ b/src/hooks/useRowHeight.ts
@@ -10,5 +10,5 @@ export function useRowHeight(rowCount: number, id: string, rowHeight: number = 1
     editTrack<BigBedConfig>(id, { height: newHeight });
   }, [rowHeight, id, editTrack, rowCount]);
 
-  return rowHeight + 2;
+  return rowHeight;
 }


### PR DESCRIPTION
Reduced transcript font size from 12 to 10 in PackTranscript and SquishTranscript components. Refactored grouping logic for transcripts and merged genes to improve memoization. Updated useRowHeight hook to return the exact rowHeight value instead of adding 2, ensuring consistent row height calculations.

Closes #28 