### PR TITLE
Add bring to bottom feature for tracks

### DIFF
--- a/src/components/tracks/wrapper/margin.tsx
+++ b/src/components/tracks/wrapper/margin.tsx
@@ -3,6 +3,7 @@ import TopIcon from "../../../icons/topIcon";
 import { useModalStore, useTrackStore, useBrowserStore, useTheme } from "../../../store/BrowserContext";
 import { useRef } from "react";
 import { BigWigConfig } from "../bigwig/types";
+import BottomIcon from "../../../icons/bottomIcon";
 
 export default function Margin({
   marginLabel,
@@ -29,8 +30,12 @@ export default function Margin({
   const settingsRef = useRef<SVGGElement>(null);
 
   const getTrackIndex = useTrackStore((state) => state.getTrackIndex);
+  const length = useTrackStore((state) => state.tracks.length);
   const shiftTracks = useTrackStore((state) => state.shiftTracks);
   const index = getTrackIndex(id);
+
+  const canBringToTop = index > 0;
+  const canBringToBottom = index < length - 1;
 
   const handleShowModal = (e: React.MouseEvent<SVGSVGElement>) => {
     e.stopPropagation();
@@ -47,6 +52,11 @@ export default function Margin({
   const handleBringToTop = (e: React.MouseEvent<SVGSVGElement>) => {
     e.stopPropagation();
     shiftTracks(id, 0);
+  };
+
+  const handleBringToBottom = (e: React.MouseEvent<SVGSVGElement>) => {
+    e.stopPropagation();
+    shiftTracks(id, -1);
   };
 
   const range = useTrackStore((state) => (state.getTrack(id) as BigWigConfig)?.range);
@@ -89,10 +99,28 @@ export default function Margin({
           </g>
         )}
         {/* bring to top icon */}
-        {index > 0 && (
-          <g onClick={handleBringToTop} style={{ cursor: "pointer" }}>
-            <TopIcon x={marginWidth / 10 + 15} y={height / 2 + 4} height={15} width={15} fill={text} />
+        {id !== "ruler" && (
+          <g onClick={canBringToTop ? handleBringToTop : undefined} style={{ cursor: "pointer" }}>
             <circle cx={marginWidth / 10 + 22.5} cy={height / 2 + 10} r={7.5} strokeWidth={0} fill="transparent" />
+            <TopIcon
+              x={marginWidth / 10 + 15}
+              y={height / 2 + 3}
+              height={15}
+              width={15}
+              fill={canBringToTop ? text : "#ccc"}
+            />
+          </g>
+        )}
+        {id !== "ruler" && (
+          <g onClick={canBringToBottom ? handleBringToBottom : undefined} style={{ cursor: "pointer" }}>
+            <circle cx={marginWidth / 10 + 37.5} cy={height / 2 + 10} r={7.5} strokeWidth={0} fill="transparent" />
+            <BottomIcon
+              x={marginWidth / 10 + 30}
+              y={height / 2 + 2}
+              height={15}
+              width={15}
+              fill={canBringToBottom ? text : "#ccc"}
+            />
           </g>
         )}
       </g>

--- a/src/icons/bottomIcon.tsx
+++ b/src/icons/bottomIcon.tsx
@@ -1,4 +1,4 @@
-export default function TopIcon(props: React.SVGProps<SVGSVGElement>) {
+export default function BottomIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       fill={props.fill || "#000000"}
@@ -6,7 +6,6 @@ export default function TopIcon(props: React.SVGProps<SVGSVGElement>) {
       y={props.y}
       width={props.width}
       height={props.height}
-      xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -15,7 +14,7 @@ export default function TopIcon(props: React.SVGProps<SVGSVGElement>) {
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
-        d="M20 4H4m8 3v11m0-11l3 3m-3-3l-3 3"
+        d="M20 20H4m8-3V6m0 11l3-3m-3 3l-3-3"
       />
     </svg>
   );

--- a/src/store/trackStore.ts
+++ b/src/store/trackStore.ts
@@ -113,7 +113,8 @@ export function createTrackStore(tracks: Track[] = []) {
         throw new Error("Track not found");
       }
       tracks.splice(state.getTrackIndex(id), 1); // Remove track from original position
-      tracks.splice(index, 0, track); // Insert track at new index
+      const realIndex = index === -1 ? tracks.length : index;
+      tracks.splice(realIndex, 0, track); // Insert track at new index
       set({ tracks, ids: tracks.map((track) => track.id) });
     },
     getTrackbyIndex: (index: number) => {


### PR DESCRIPTION
Introduces a BottomIcon component and updates the track margin UI to allow users to move tracks to the bottom. The shiftTracks logic is updated to handle the new action, and TopIcon is refactored for consistency.

Closes #36 