### PR TITLE
Allow modal to close with Enter key

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -35,7 +35,7 @@ export default function Modal() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") closeModal();
+      if (event.key === "Escape" || event.key === "Enter") closeModal();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => {
@@ -162,4 +162,3 @@ function CloseButton({ handleClose, color }: { handleClose: () => void; color: s
     </svg>
   );
 }
-


### PR DESCRIPTION
Added support for closing the modal when the Enter key is pressed, in addition to the Escape key, to improve accessibility and user experience.

Closes #35 