### PR TITLE
Fix track error message layout

### DIFF
--- a/packages/core/src/browser/track-row/ErrorState.tsx
+++ b/packages/core/src/browser/track-row/ErrorState.tsx
@@ -13,11 +13,29 @@ export function ErrorState({
   height: number;
   message: string;
 }) {
-  const size = Math.max(18, Math.min(height / 3, 40));
+  const minIconSize = 18;
+  const maxIconSize = 40;
+  const minFontSize = 8;
+  const maxFontSize = 12;
+  const gap = 2;
+  const showIcon = height >= minIconSize + gap + minFontSize;
+  const fontSize = showIcon
+    ? Math.min(maxFontSize, height - minIconSize - gap)
+    : Math.min(maxFontSize, height);
+  const size = showIcon
+    ? Math.min(maxIconSize, Math.max(minIconSize, height / 3), height - gap - fontSize)
+    : 0;
   return (
-    <g transform={`translate(${x + (width - size) / 2},${y + (height - size) / 2})`}>
-      <ErrorIcon outline="#000000" inside="#ffffff" width={size} height={size} />
-      <text fill="#000000" textAnchor="middle" fontSize="12px" x={size / 2} y={size + 14}>
+    <g transform={`translate(${x + (width - size) / 2},${y})`}>
+      {showIcon && <ErrorIcon outline="#000000" inside="#ffffff" width={size} height={size} />}
+      <text
+        fill="#000000"
+        textAnchor="middle"
+        dominantBaseline="hanging"
+        fontSize={`${fontSize}px`}
+        x={size / 2}
+        y={showIcon ? size + gap : 0}
+      >
         {message}
       </text>
     </g>

--- a/packages/core/src/browser/track-row/TrackContent.tsx
+++ b/packages/core/src/browser/track-row/TrackContent.tsx
@@ -14,14 +14,12 @@ export const TrackContent = memo(function TrackContent({
   region,
   width,
   height,
-  titleMargin,
 }: {
   track: AnyTrackInstance;
   dataState: DataState;
   region: BrowserRegion;
   width: number;
   height: number;
-  titleMargin: number;
 }) {
   const registry = useRegistry();
 
@@ -29,15 +27,7 @@ export const TrackContent = memo(function TrackContent({
     return <LoadingState x={0} y={0} width={width} height={height} />;
   }
   if (dataState.status === "error") {
-    return (
-      <ErrorState
-        x={0}
-        y={0}
-        width={width}
-        height={height + titleMargin}
-        message={dataState.error}
-      />
-    );
+    return <ErrorState x={0} y={0} width={width} height={height} message={dataState.error} />;
   }
 
   try {

--- a/packages/core/src/browser/track-row/TrackStack.tsx
+++ b/packages/core/src/browser/track-row/TrackStack.tsx
@@ -8,7 +8,7 @@ import type { SwapPreview } from "./swapTypes";
 import type { PanDragHandlers } from "../viewport/usePanDrag";
 import { TrackContent } from "./TrackContent";
 import { TrackFrame } from "./TrackFrame";
-import { getTrackTitleMargin, getTrackWrapperHeight } from "./trackLayout";
+import { getTrackWrapperHeight } from "./trackLayout";
 
 export function TrackStack({
   tracks,
@@ -49,7 +49,6 @@ export function TrackStack({
   return tracks.map((track, index) => {
     const trackY = y;
     const wrapperHeight = getTrackWrapperHeight(track, titleSize);
-    const titleMargin = getTrackTitleMargin(track, titleSize);
     const previewOffsetY = getSwapPreviewOffsetY(
       index,
       track.base.id,
@@ -90,7 +89,6 @@ export function TrackStack({
               region={region}
               width={contentWidth ?? trackWidth}
               height={track.base.height}
-              titleMargin={titleMargin}
             />
           </TrackFrame>
         )}

--- a/packages/core/test/browser/browserWiring.test.tsx
+++ b/packages/core/test/browser/browserWiring.test.tsx
@@ -28,6 +28,64 @@ import type {
 describe("browser module wiring", () => {
   const region = { chromosome: "chr1", start: 0, end: 10 };
 
+  it("positions fetch errors at the top of the track content", () => {
+    const module = defineTrackModule({
+      type: "error-alignment-test",
+      configSchema: z.object({}),
+      fetch: async () => null,
+      render: { full: () => null },
+    });
+    const track = module.create({ id: "error", title: "Error", config: {}, height: 60 });
+    const trackStore = createTrackStore({ modules: [module], tracks: [track] });
+
+    const markup = renderToStaticMarkup(
+      <RegistryProvider registry={trackStore.getState().registry}>
+        <TrackContent
+          track={track}
+          dataState={{ status: "error", error: "Failed to load" }}
+          region={region}
+          width={100}
+          height={track.base.height}
+        />
+      </RegistryProvider>,
+    );
+
+    expect(markup).toContain('transform="translate(40,0)"');
+    expect(markup).toContain("Failed to load");
+  });
+
+  it("hides the error icon and scales the message for short tracks", () => {
+    const module = defineTrackModule({
+      type: "short-error-test",
+      configSchema: z.object({}),
+      fetch: async () => null,
+      render: { full: () => null },
+    });
+    const track = module.create({
+      id: "short-error",
+      title: "Short error",
+      config: {},
+      height: 10,
+    });
+    const trackStore = createTrackStore({ modules: [module], tracks: [track] });
+
+    const markup = renderToStaticMarkup(
+      <RegistryProvider registry={trackStore.getState().registry}>
+        <TrackContent
+          track={track}
+          dataState={{ status: "error", error: "Failed to load" }}
+          region={region}
+          width={100}
+          height={track.base.height}
+        />
+      </RegistryProvider>,
+    );
+
+    expect(markup).not.toContain("<svg");
+    expect(markup).toContain('font-size="10px"');
+    expect(markup).toContain('transform="translate(50,0)"');
+  });
+
   it("binds current runtime context while keeping renderer callbacks item-only", () => {
     type Item = { id: string };
     type Config = { url: string; enabled: boolean };
@@ -69,7 +127,6 @@ describe("browser module wiring", () => {
             region={region}
             width={100}
             height={80}
-            titleMargin={0}
           />
         </RegistryProvider>,
       );
@@ -154,7 +211,6 @@ describe("browser module wiring", () => {
                 region={region}
                 width={100}
                 height={80}
-                titleMargin={0}
               />
             </RegistryProvider>
           </TooltipContextProvider>


### PR DESCRIPTION
## Summary
- keep track error states within the content bounds
- top-align error content and adapt icon/text sizing for short tracks
- remove redundant title-margin height adjustment and add regression coverage

## Verification
- `pnpm exec vitest run` (137 tests)
- `pnpm exec tsc -p tsconfig.app.json --noEmit`
- `pnpm run lint`
- `pnpm run format:check`

Fixes #91