### PR TITLE
Isolate track and tooltip render failures

### DIFF
--- a/packages/core/docs/troubleshooting.md
+++ b/packages/core/docs/troubleshooting.md
@@ -22,6 +22,12 @@ Fetch failures appear in the affected track's error state. Check browser network
 
 For Transcript failures, confirm the host implements the default `/api/screen-graphql` route or that the track's `config.endpoint` names the intended alternative. The module does not construct an authorization header. If the upstream service requires a credential, point the track at an application-owned server proxy and verify that the proxy adds the credential server-side.
 
+## Custom renderer or tooltip failure
+
+An unexpected error while React renders a custom track renderer is contained to that track's content area. An error from custom tooltip content is replaced by `Tooltip unavailable`; hide the tooltip or show one from another track to clear that fallback. Other tracks and browser controls remain available in both cases.
+
+Inspect the original error and React component stack in the browser console. Contained track failures use the `[genomebrowser] Track render error` prefix, and contained tooltip failures use `[genomebrowser] Tooltip render error`.
+
 ## Browser is blank, clipped, or too wide
 
 The browser does not measure its parent. Set `trackWidth` to a positive value and update it from a `ResizeObserver` when the container changes. The complete SVG width is `marginWidth + trackWidth`, so subtract the margin from the measured host width if the browser should fit exactly.

--- a/packages/core/src/browser/RenderErrorBoundary.tsx
+++ b/packages/core/src/browser/RenderErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type RenderErrorBoundaryProps = {
+  children: ReactNode;
+  fallback: ReactNode;
+  onError?: (error: unknown, info: ErrorInfo) => void;
+};
+
+type RenderErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class RenderErrorBoundary extends Component<
+  RenderErrorBoundaryProps,
+  RenderErrorBoundaryState
+> {
+  state: RenderErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): RenderErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}

--- a/packages/core/src/browser/tooltip/TooltipOverlay.tsx
+++ b/packages/core/src/browser/tooltip/TooltipOverlay.tsx
@@ -1,12 +1,15 @@
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState, type ErrorInfo } from "react";
+import { RenderErrorBoundary } from "../RenderErrorBoundary";
 import { useInternalTooltipStore } from "./tooltipContextState";
 
 const TOOLTIP_OFFSET = 10;
+const tooltipRenderErrorPrefix = "[genomebrowser] Tooltip render error";
 
 export function TooltipOverlay({ width, height }: { width: number; height: number }) {
   const content = useInternalTooltipStore((state) => state.content);
   const isVisible = useInternalTooltipStore((state) => state.isVisible);
   const anchor = useInternalTooltipStore((state) => state.anchor);
+  const owner = useInternalTooltipStore((state) => state.owner);
   const ref = useRef<SVGGElement>(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
@@ -37,7 +40,39 @@ export function TooltipOverlay({ width, height }: { width: number; height: numbe
       transform={`translate(${position.x},${position.y})`}
       style={{ pointerEvents: "none" }}
     >
-      {content}
+      <RenderErrorBoundary
+        key={owner}
+        fallback={<TooltipErrorFallback />}
+        onError={reportTooltipRenderError}
+      >
+        {content}
+      </RenderErrorBoundary>
     </g>
   );
+}
+
+function TooltipErrorFallback() {
+  return (
+    <g>
+      <rect width={144} height={30} rx={2} fill="#ffffff" stroke="#cccccc" />
+      <text
+        x={72}
+        y={15}
+        fill="#000000"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="12px"
+      >
+        Tooltip unavailable
+      </text>
+    </g>
+  );
+}
+
+function reportTooltipRenderError(error: unknown, info: ErrorInfo) {
+  console.error(tooltipRenderErrorPrefix, {
+    extensionPoint: "tooltip content",
+    error,
+    ...(info.componentStack ? { componentStack: info.componentStack } : {}),
+  });
 }

--- a/packages/core/src/browser/track-row/TrackContent.tsx
+++ b/packages/core/src/browser/track-row/TrackContent.tsx
@@ -30,52 +30,40 @@ export const TrackContent = memo(function TrackContent({
     return <ErrorState x={0} y={0} width={width} height={height} message={dataState.error} />;
   }
 
-  try {
-    const module = registry.get(track.type);
-    const Renderer = module.render[track.base.display] as
-      | ComponentType<TrackRendererProps<unknown, unknown>>
-      | undefined;
-    if (!Renderer) {
-      return (
-        <ErrorState
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          message={`Display "${track.base.display}" is not supported by "${track.type}"`}
-        />
-      );
-    }
-    const context = {
-      type: track.type,
-      base: track.base,
-      config: track.config,
-    };
-    const interaction = bindTrackInteraction(track.interaction, context);
-    return (
-      <TrackRuntimeContextProvider context={context}>
-        <TrackInteractionProvider interaction={interaction}>
-          <Renderer
-            id={track.base.id}
-            config={track.config}
-            color={track.base.color}
-            data={dataState.data}
-            region={region}
-            width={width}
-            height={height}
-          />
-        </TrackInteractionProvider>
-      </TrackRuntimeContextProvider>
-    );
-  } catch (error) {
+  const module = registry.get(track.type);
+  const Renderer = module.render[track.base.display] as
+    | ComponentType<TrackRendererProps<unknown, unknown>>
+    | undefined;
+  if (!Renderer) {
     return (
       <ErrorState
         x={0}
         y={0}
         width={width}
         height={height}
-        message={error instanceof Error ? error.message : "Unknown error"}
+        message={`Display "${track.base.display}" is not supported by "${track.type}"`}
       />
     );
   }
+  const context = {
+    type: track.type,
+    base: track.base,
+    config: track.config,
+  };
+  const interaction = bindTrackInteraction(track.interaction, context);
+  return (
+    <TrackRuntimeContextProvider context={context}>
+      <TrackInteractionProvider interaction={interaction}>
+        <Renderer
+          id={track.base.id}
+          config={track.config}
+          color={track.base.color}
+          data={dataState.data}
+          region={region}
+          width={width}
+          height={height}
+        />
+      </TrackInteractionProvider>
+    </TrackRuntimeContextProvider>
+  );
 });

--- a/packages/core/src/browser/track-row/TrackStack.tsx
+++ b/packages/core/src/browser/track-row/TrackStack.tsx
@@ -1,14 +1,18 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ErrorInfo } from "react";
 import type { DataState } from "../data/types";
 import type { AnyTrackInstance } from "../../modules/types";
 import type { BrowserRegion } from "../../modules/utils/region";
+import { RenderErrorBoundary } from "../RenderErrorBoundary";
 import { SwapTrack } from "./SwapTrack";
 import { getSwapPreviewOffsetY, isSameSwapPreview } from "./trackSwapMath";
 import type { SwapPreview } from "./swapTypes";
 import type { PanDragHandlers } from "../viewport/usePanDrag";
 import { TrackContent } from "./TrackContent";
 import { TrackFrame } from "./TrackFrame";
+import { ErrorState } from "./ErrorState";
 import { getTrackWrapperHeight } from "./trackLayout";
+
+const trackRenderErrorPrefix = "[genomebrowser] Track render error";
 
 export function TrackStack({
   tracks,
@@ -83,16 +87,42 @@ export function TrackStack({
             disableHover={!!swapPreview}
             titleSize={titleSize}
           >
-            <TrackContent
-              track={track}
-              dataState={dataStates[track.base.id]}
-              region={region}
-              width={contentWidth ?? trackWidth}
-              height={track.base.height}
-            />
+            <RenderErrorBoundary
+              fallback={
+                <ErrorState
+                  x={0}
+                  y={0}
+                  width={contentWidth ?? trackWidth}
+                  height={track.base.height}
+                  message={`Track unavailable: ${track.base.title || track.base.id}`}
+                />
+              }
+              onError={(error, info) => reportTrackRenderError(track, error, info)}
+            >
+              <TrackContent
+                track={track}
+                dataState={dataStates[track.base.id]}
+                region={region}
+                width={contentWidth ?? trackWidth}
+                height={track.base.height}
+              />
+            </RenderErrorBoundary>
           </TrackFrame>
         )}
       </SwapTrack>
     );
+  });
+}
+
+function reportTrackRenderError(track: AnyTrackInstance, error: unknown, info: ErrorInfo) {
+  console.error(trackRenderErrorPrefix, {
+    track: {
+      id: track.base.id,
+      type: track.type,
+      display: track.base.display,
+      ...(track.base.title ? { title: track.base.title } : {}),
+    },
+    error,
+    ...(info.componentStack ? { componentStack: info.componentStack } : {}),
   });
 }

--- a/packages/core/test/browser/tooltipRenderErrorIsolation.test.tsx
+++ b/packages/core/test/browser/tooltipRenderErrorIsolation.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipContextProvider } from "../../src/browser/tooltip/TooltipContext";
+import { TooltipOverlay } from "../../src/browser/tooltip/TooltipOverlay";
+import {
+  createTooltipStore,
+  type TooltipStoreInstance,
+} from "../../src/browser/tooltip/tooltipStore";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const tooltipRenderErrorPrefix = "[genomebrowser] Tooltip render error";
+const renderError = new Error("private tooltip exception");
+const originalGetBBox = Object.getOwnPropertyDescriptor(SVGElement.prototype, "getBBox");
+
+let container: HTMLDivElement | undefined;
+let root: Root | undefined;
+let store: TooltipStoreInstance;
+
+beforeEach(async () => {
+  Object.defineProperty(SVGElement.prototype, "getBBox", {
+    configurable: true,
+    value: vi.fn(() => ({ x: 0, y: 0, width: 144, height: 30 })),
+  });
+  store = createTooltipStore();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(
+      <TooltipContextProvider
+        isDisabled={() => false}
+        getTooltipComponent={() => undefined}
+        store={store}
+      >
+        <BrowserSurface />
+      </TooltipContextProvider>,
+    );
+  });
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  container?.remove();
+  container = undefined;
+  root = undefined;
+  vi.restoreAllMocks();
+  if (originalGetBBox) {
+    Object.defineProperty(SVGElement.prototype, "getBBox", originalGetBBox);
+  } else {
+    Reflect.deleteProperty(SVGElement.prototype, "getBBox");
+  }
+});
+
+describe("tooltip render error isolation", () => {
+  it("contains throwing content and reports safe tooltip context", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const privateItem = { secret: "private tooltip item" };
+
+    await show("broken-owner", <ThrowingTooltip item={privateItem} />, { x: 40, y: 50 });
+
+    const fallback = requiredText("Tooltip unavailable");
+    const fallbackGroup = fallback.parentElement;
+    const fallbackRect = fallbackGroup?.querySelector("rect");
+    expect(fallbackRect?.getAttribute("width")).toBe("144");
+    expect(fallbackRect?.getAttribute("height")).toBe("30");
+    expect(container?.textContent).not.toContain(renderError.message);
+    expect(requiredElement('[data-testid="track-content"]')).toBeTruthy();
+    expect(requiredElement('[data-testid="browser-navigation"]')).toBeTruthy();
+    expect(requiredElement('[data-testid="unrelated-overlay"]')).toBeTruthy();
+
+    await act(async () =>
+      requiredElement('[data-testid="browser-navigation"]').dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      ),
+    );
+    expect(requiredText("Navigation updates: 1")).toBeTruthy();
+    expect(requiredText("Tooltip unavailable")).toBe(fallback);
+
+    const customLog = consoleError.mock.calls.find(
+      ([message]) => message === tooltipRenderErrorPrefix,
+    );
+    expect(customLog?.[1]).toEqual({
+      extensionPoint: "tooltip content",
+      error: renderError,
+      componentStack: expect.stringContaining("ThrowingTooltip"),
+    });
+    expect(JSON.stringify(customLog?.[1])).not.toContain(privateItem.secret);
+  });
+
+  it("renders content from a different owner after a failure", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await show("broken-owner", <ThrowingTooltip item={{ secret: "hidden" }} />, {
+      x: 40,
+      y: 50,
+    });
+
+    await show("healthy-owner", <text>Healthy tooltip</text>, { x: 80, y: 90 });
+
+    expect(requiredText("Healthy tooltip")).toBeTruthy();
+    expect(container?.textContent).not.toContain("Tooltip unavailable");
+  });
+
+  it("recovers after the failed tooltip is hidden and shown again", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await show("same-owner", <ThrowingTooltip item={{ secret: "hidden" }} />, { x: 40, y: 50 });
+
+    await act(async () => store.getState().hide("same-owner"));
+    expect(container?.textContent).not.toContain("Tooltip unavailable");
+
+    await show("same-owner", <text>Recovered tooltip</text>, { x: 60, y: 70 });
+    expect(requiredText("Recovered tooltip")).toBeTruthy();
+  });
+
+  it("does not retry failed content during same-owner movement", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const renderTooltip = vi.fn();
+    await show("moving-owner", <CountingThrowingTooltip onRender={renderTooltip} />, {
+      x: 40,
+      y: 50,
+    });
+    const renderCountAfterFailure = renderTooltip.mock.calls.length;
+    const reportCountAfterFailure = customReportCount(consoleError.mock.calls);
+
+    await show("moving-owner", <CountingThrowingTooltip onRender={renderTooltip} />, {
+      x: 120,
+      y: 130,
+    });
+    await show("moving-owner", <CountingThrowingTooltip onRender={renderTooltip} />, {
+      x: 140,
+      y: 150,
+    });
+
+    expect(requiredText("Tooltip unavailable")).toBeTruthy();
+    expect(renderTooltip).toHaveBeenCalledTimes(renderCountAfterFailure);
+    expect(customReportCount(consoleError.mock.calls)).toBe(reportCountAfterFailure);
+    expect(
+      requiredText("Tooltip unavailable").parentElement?.parentElement?.getAttribute("transform"),
+    ).toBe("translate(150,160)");
+  });
+});
+
+function BrowserSurface() {
+  const [navigationUpdates, setNavigationUpdates] = useState(0);
+
+  return (
+    <svg>
+      <g data-testid="track-content">
+        <text>Track remains available</text>
+      </g>
+      <g
+        data-testid="browser-navigation"
+        onClick={() => setNavigationUpdates((count) => count + 1)}
+      >
+        <rect width={20} height={20} />
+        <text>Navigation updates: {navigationUpdates}</text>
+      </g>
+      <g data-testid="unrelated-overlay" />
+      <TooltipOverlay width={500} height={300} />
+    </svg>
+  );
+}
+
+function ThrowingTooltip({ item: _item }: { item: { secret: string } }): never {
+  throw renderError;
+}
+
+function CountingThrowingTooltip({ onRender }: { onRender: () => void }): never {
+  onRender();
+  throw renderError;
+}
+
+async function show(owner: string, content: React.ReactElement, anchor: { x: number; y: number }) {
+  await act(async () => store.getState().show(owner, content, anchor));
+}
+
+function customReportCount(calls: unknown[][]) {
+  return calls.filter(([message]) => message === tooltipRenderErrorPrefix).length;
+}
+
+function requiredText(content: string) {
+  const element = Array.from(container?.querySelectorAll("text") ?? []).find(
+    (candidate) => candidate.textContent === content,
+  );
+  if (!element) throw new Error(`Text not found: ${content}`);
+  return element;
+}
+
+function requiredElement<E extends Element = Element>(selector: string) {
+  const element = container?.querySelector<E>(selector);
+  if (!element) throw new Error(`Element not found: ${selector}`);
+  return element;
+}

--- a/packages/core/test/browser/trackRenderErrorIsolation.test.tsx
+++ b/packages/core/test/browser/trackRenderErrorIsolation.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { GenomeBrowser } from "../../src/browser/GenomeBrowser";
+import type { DataState } from "../../src/browser/data/types";
+import { createBrowserStore } from "../../src/browser/state/browserStore";
+import { RegistryProvider } from "../../src/browser/state/RegistryContext";
+import { createTrackStore } from "../../src/browser/state/trackStore";
+import { TrackContent } from "../../src/browser/track-row/TrackContent";
+import { defineTrackModule } from "../../src/modules/defineTrackModule";
+import type { AnyTrackInstance } from "../../src/modules/types";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const trackRenderErrorPrefix = "[genomebrowser] Track render error";
+const renderError = new Error("private renderer exception");
+
+function ThrowingRenderer(): never {
+  throw renderError;
+}
+
+function HealthyRenderer() {
+  return <rect data-testid="healthy-renderer" width={100} height={20} />;
+}
+
+const throwingModule = defineTrackModule({
+  type: "throwing-render-test",
+  configSchema: z.object({ secret: z.string() }),
+  fetch: async () => ({ privateData: "private fetched data" }),
+  render: { full: ThrowingRenderer },
+});
+
+const healthyModule = defineTrackModule({
+  type: "healthy-render-test",
+  configSchema: z.object({}),
+  fetch: async () => null,
+  render: { full: HealthyRenderer },
+});
+
+let container: HTMLDivElement | undefined;
+let root: Root | undefined;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  container?.remove();
+  container = undefined;
+  root = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("track render error isolation", () => {
+  it("contains a throwing renderer within its track frame and logs safe context", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const brokenTrack = throwingModule.create({
+      id: "broken-track",
+      title: "Broken track",
+      height: 64,
+      config: { secret: "private track config" },
+    });
+    const healthyTrack = healthyModule.create({
+      id: "healthy-track",
+      title: "Healthy track",
+      height: 48,
+      config: {},
+    });
+    const browserStore = createBrowserStore({
+      region: "chr1:1-1000",
+      marginWidth: 120,
+      trackWidth: 500,
+      titleSize: 12,
+    });
+    const trackStore = createTrackStore({
+      modules: [throwingModule, healthyModule],
+      tracks: [brokenTrack, healthyTrack],
+    });
+
+    await render(<GenomeBrowser browserStore={browserStore} trackStore={trackStore} />);
+
+    const svg = requiredElement<SVGSVGElement>("#browserSVG");
+    const fallbackText = requiredText("Track unavailable: Broken track");
+    const brokenTitle = requiredText("Broken track");
+    const brokenFrame = brokenTitle.parentElement;
+    if (!brokenFrame) throw new Error("Broken track frame not found");
+
+    expect(container?.textContent).not.toContain(renderError.message);
+    expect(requiredElement('[data-testid="healthy-renderer"]')).toBeTruthy();
+    expect(requiredText("Healthy track")).toBeTruthy();
+    expect(brokenFrame.getAttribute("transform")).toBe("translate(0,80)");
+    expect(brokenFrame.querySelector('rect[x="120"][y="0"][height="81"]')).toBeTruthy();
+    expect(brokenFrame.querySelectorAll('svg[viewBox="0 0 24 24"]')).toHaveLength(3);
+    expect(brokenFrame.querySelector("g[clip-path]")?.contains(fallbackText)).toBe(true);
+    expect(fallbackText.parentElement?.parentElement?.firstElementChild?.tagName).toBe("rect");
+    expect(requiredText("Healthy track").parentElement?.getAttribute("transform")).toBe(
+      "translate(0,161)",
+    );
+    expect(svg.getAttribute("viewBox")).toBe("0 0 620 226");
+    expect(svg.querySelector('rect[x="120"][y="0"][width="500"][height="80"]')).toBeTruthy();
+
+    await act(async () => browserStore.getState().zoom(0.5));
+    expect(browserStore.getState().region).toEqual({ chromosome: "chr1", start: 251, end: 751 });
+    expect(requiredElement("#browserSVG")).toBe(svg);
+    expect(requiredElement('[data-testid="healthy-renderer"]')).toBeTruthy();
+    expect(requiredText("Track unavailable: Broken track")).toBeTruthy();
+
+    const customLog = consoleError.mock.calls.find(
+      ([message]) => message === trackRenderErrorPrefix,
+    );
+    expect(customLog?.[1]).toEqual({
+      track: {
+        id: "broken-track",
+        type: "throwing-render-test",
+        display: "full",
+        title: "Broken track",
+      },
+      error: renderError,
+      componentStack: expect.stringContaining("ThrowingRenderer"),
+    });
+    expect(JSON.stringify(customLog?.[1])).not.toContain("private track config");
+    expect(JSON.stringify(customLog?.[1])).not.toContain("private fetched data");
+  });
+
+  it("keeps loading, fetch-error, and unsupported-display states explicit", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const renderer = vi.fn(HealthyRenderer);
+    const module = defineTrackModule({
+      type: "expected-state-test",
+      configSchema: z.object({}),
+      fetch: async () => null,
+      render: { full: renderer },
+    });
+    const track = module.create({ id: "expected", title: "Expected states", config: {} });
+    const unsupportedTrack: AnyTrackInstance = {
+      ...track,
+      base: { ...track.base, id: "unsupported", display: "missing" },
+    };
+    const trackStore = createTrackStore({ modules: [module], tracks: [track] });
+
+    await render(
+      <RegistryProvider registry={trackStore.getState().registry}>
+        <svg>
+          <TrackState track={track} dataState={{ status: "loading" }} />
+          <TrackState
+            track={track}
+            dataState={{ status: "error", error: "Expected fetch failure" }}
+          />
+          <TrackState track={unsupportedTrack} dataState={{ status: "success", data: null }} />
+        </svg>
+      </RegistryProvider>,
+    );
+
+    expect(requiredElement("animateTransform")).toBeTruthy();
+    expect(requiredText("Expected fetch failure")).toBeTruthy();
+    expect(
+      requiredText('Display "missing" is not supported by "expected-state-test"'),
+    ).toBeTruthy();
+    expect(renderer).not.toHaveBeenCalled();
+    expect(consoleError.mock.calls.some(([message]) => message === trackRenderErrorPrefix)).toBe(
+      false,
+    );
+  });
+});
+
+function TrackState({ track, dataState }: { track: AnyTrackInstance; dataState: DataState }) {
+  return (
+    <g>
+      <TrackContent
+        track={track}
+        dataState={dataState}
+        region={{ chromosome: "chr1", start: 0, end: 100 }}
+        width={100}
+        height={track.base.height}
+      />
+    </g>
+  );
+}
+
+async function render(children: React.ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(children);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function requiredText(content: string) {
+  const element = Array.from(container?.querySelectorAll("text") ?? []).find(
+    (candidate) => candidate.textContent === content,
+  );
+  if (!element) throw new Error(`Text not found: ${content}`);
+  return element;
+}
+
+function requiredElement<E extends Element = Element>(selector: string) {
+  const element = container?.querySelector<E>(selector);
+  if (!element) throw new Error(`Element not found: ${selector}`);
+  return element;
+}


### PR DESCRIPTION
## Summary
- isolate each custom track renderer with a bounded SVG fallback
- isolate custom tooltip content and reset failures across tooltip owners
- add contextual diagnostics, regression coverage, and troubleshooting guidance

## Verification
- `pnpm test:core` (143 tests)
- `pnpm lint:core`
- `pnpm format:check:core`
- `pnpm build:core`
- manual failure-module verification in the core harness

Closes #97